### PR TITLE
fix memory corruption in OnScriptError()

### DIFF
--- a/tsc64/tsc64.cpp
+++ b/tsc64/tsc64.cpp
@@ -574,7 +574,7 @@ STDMETHODIMP CTScriptControl::Invoke(DISPID dispIdMember, REFIID riid, LCID lcid
 	VARIANT v; VariantInit(&v);
 	HRESULT hr = S_OK;
 
-	// used by CteActiveScriptSite::OnScriptError::OnScriptError to pass info to our caller
+	// used by CteActiveScriptSite::OnScriptError to pass info to our caller
 	m_pEI = pExcepInfo;
 
 	switch (dispIdMember) {
@@ -731,7 +731,7 @@ STDMETHODIMP CTScriptControl::Invoke(DISPID dispIdMember, REFIID riid, LCID lcid
 			break;
 	}//end_switch
 	
-	// no more caller for CteActiveScriptSite::OnScriptError::OnScriptError
+	// no more caller for CteActiveScriptSite::OnScriptError
 	m_pEI = NULL;
 	return hr;
 }

--- a/tsc64/tsc64.cpp
+++ b/tsc64/tsc64.cpp
@@ -574,7 +574,7 @@ STDMETHODIMP CTScriptControl::Invoke(DISPID dispIdMember, REFIID riid, LCID lcid
 	VARIANT v; VariantInit(&v);
 	HRESULT hr = S_OK;
 
-	// used by CTScriptError::OnScriptError to pass info to our caller
+	// used by CteActiveScriptSite::OnScriptError::OnScriptError to pass info to our caller
 	m_pEI = pExcepInfo;
 
 	switch (dispIdMember) {
@@ -731,7 +731,7 @@ STDMETHODIMP CTScriptControl::Invoke(DISPID dispIdMember, REFIID riid, LCID lcid
 			break;
 	}//end_switch
 	
-	// no more caller for CTScriptError::OnScriptError
+	// no more caller for CteActiveScriptSite::OnScriptError::OnScriptError
 	m_pEI = NULL;
 	return hr;
 }


### PR DESCRIPTION
Fix memory corruption when `CteActiveScriptSite::OnScriptError()` is called by the engine outside of a `CTScriptControl::Invoke()` context.

An example situation where this can occur is when a script contains code that will generate an exception:
JScript `function test() { throw new Error("Test Exception") }`
and this function is passed outside the ScriptControl, as a callback or through the `CodeObject` property. External code can then call the function directly, and `CteActiveScriptSite::OnScriptError()` will be called with a stale `m_pEI` pointer, which can lead to stack or heap corruption when it is filled in.

This change ensures `m_pEI` is only used while `CTScriptControl::Invoke()` is in progress.